### PR TITLE
window size position memory

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,6 +48,10 @@ app.on('ready', () => {
       });
     });
 
+    socket.on('player/fullscreen', (isFullscreen) => {
+      Windows.toggleFullscreen(isFullscreen);
+    });
+
     // Video
     socket.on('video/start', (id) => {
       console.log('Video started: ', id);

--- a/src/app.js
+++ b/src/app.js
@@ -48,6 +48,10 @@ app.on('ready', () => {
       });
     });
 
+    socket.on('config/mode', (mode) => {
+      Windows.switchMode(mode);
+    });
+
     socket.on('player/fullscreen', (isFullscreen) => {
       Windows.toggleFullscreen(isFullscreen);
     });

--- a/src/app.js
+++ b/src/app.js
@@ -48,10 +48,6 @@ app.on('ready', () => {
       });
     });
 
-    socket.on('config/mode', (mode) => {
-      Windows.switchMode(mode);
-    });
-
     socket.on('player/fullscreen', (isFullscreen) => {
       Windows.toggleFullscreen(isFullscreen);
     });

--- a/src/app.js
+++ b/src/app.js
@@ -48,8 +48,8 @@ app.on('ready', () => {
       });
     });
 
-    socket.on('player/fullscreen', (isFullscreen) => {
-      Windows.toggleFullscreen(isFullscreen);
+    socket.on('player/floatontop', (isPlayerMaximized) => {
+      Windows.togglePlayerState(isPlayerMaximized);
     });
 
     // Video

--- a/src/app.js
+++ b/src/app.js
@@ -86,6 +86,10 @@ app.on('ready', () => {
         }
       });
     });
+
+    Windows.setOnNumberOfDisplayChangeHandler((sortedDisplaysIds) => {
+      socket.emit('number-of-display/update', sortedDisplaysIds);
+    });
   });
 
   server.hapi.route({

--- a/src/client/scripts/components/switch.react.js
+++ b/src/client/scripts/components/switch.react.js
@@ -41,7 +41,7 @@ const Switch = React.createClass({
 
         {beforeText}
 
-        <input type="checkbox" defaultChecked={this.props.isChecked} onChange={this.props.onChange} />
+        <input type="checkbox" checked={this.props.isChecked} onChange={this.props.onChange} />
 
         <div className="z-switch--container">
           <div className="z-switch--slider" data-on={this.props.textOn} data-off={this.props.textOff} />

--- a/src/client/scripts/pages/configuration.react.js
+++ b/src/client/scripts/pages/configuration.react.js
@@ -44,6 +44,20 @@ const ConfigurationPage = React.createClass({
       mode: Utils.getMode(),
     };
   },
+  componentDidMount() {
+    Utils.Socket.on('number-of-display/update', this.onNumberOfDisplayChange);
+  },
+  componentWillUnmout() {
+    Utils.Socket.removeAllListeners('number-of-display/update');
+  },
+  onNumberOfDisplayChange() {
+    this.setState({
+      showConsole: this.state.showConsole,
+      darkTheme: this.state.darkTheme,
+      layout: this.state.layout,
+      mode: Utils.getMode(),
+    });
+  },
   render() {
     return (
       <div className="text-page">

--- a/src/client/scripts/pages/configuration.react.js
+++ b/src/client/scripts/pages/configuration.react.js
@@ -50,8 +50,8 @@ const ConfigurationPage = React.createClass({
         <h1>Configuration</h1>
         <form>
           <div className="form-group row">
-            <label className="col-sm-4">Dark Theme</label>
-            <div className="col-sm-8">
+            <label className="col-sm-4 col-form-label">Dark Theme</label>
+            <div className="col-sm-8 col-form-label">
               <Switch
                 isChecked={this.state.darkTheme}
                 onChange={this.toggleDarkTheme}
@@ -63,7 +63,7 @@ const ConfigurationPage = React.createClass({
             </div>
           </div>
           <div className="form-group row">
-            <label className="col-sm-4">Layout</label>
+            <label className="col-sm-4 col-form-label">Layout</label>
             <div className="col-sm-8">
               <div className="select">
                 <select className="form-control" value={this.state.layout} onChange={this.changeLayout}>
@@ -75,17 +75,20 @@ const ConfigurationPage = React.createClass({
             </div>
           </div>
           <div className="form-group row">
-            <label className="col-sm-4">Resize when going fullscreen</label>
-            <div className="col-sm-8">
+            <div className="col-sm-2 col-form-label">Mode</div>
+            <label className="col-sm-2 col-form-label">
+              <span className="pull-right">Fullscreen</span>
+            </label>
+            <div className="col-sm-1 col-form-label">
               <Switch
                 isChecked={this.state.doResize}
                 onChange={this.toggleResize}
+                color="1"
                 size="lg"
-                textOn="I"
-                textOff="O"
                 shape="square"
                 />
             </div>
+            <label className="col-sm-7 col-form-label">Float-on-top</label>
           </div>
         </form>
       </div>

--- a/src/client/scripts/pages/configuration.react.js
+++ b/src/client/scripts/pages/configuration.react.js
@@ -11,10 +11,10 @@ const ConfigurationPage = React.createClass({
 
     this.setState({ darkTheme });
   },
-  toggleResize() {
-    const doResize = Utils.toggleResize();
+  toggleMode() {
+    const mode = Utils.toggleMode();
 
-    this.setState({ doResize });
+    this.setState({ mode });
   },
   changeLayout(event) {
     const layout = event.target.value;
@@ -41,7 +41,7 @@ const ConfigurationPage = React.createClass({
       showConsole: false,
       darkTheme : Utils.isDarkThemeActive(),
       layout: Utils.getActiveLayout(),
-      doResize: Utils.shouldResize(),
+      mode: Utils.getMode(),
     };
   },
   render() {
@@ -81,8 +81,8 @@ const ConfigurationPage = React.createClass({
             </label>
             <div className="col-sm-1 col-form-label">
               <Switch
-                isChecked={this.state.doResize}
-                onChange={this.toggleResize}
+                isChecked={this.state.getMode}
+                onChange={this.toggleMode}
                 color="1"
                 size="lg"
                 shape="square"

--- a/src/client/scripts/pages/configuration.react.js
+++ b/src/client/scripts/pages/configuration.react.js
@@ -81,7 +81,7 @@ const ConfigurationPage = React.createClass({
             </label>
             <div className="col-sm-1 col-form-label">
               <Switch
-                isChecked={this.state.getMode}
+                isChecked={this.state.mode}
                 onChange={this.toggleMode}
                 color="1"
                 size="lg"

--- a/src/client/scripts/pages/configuration.react.js
+++ b/src/client/scripts/pages/configuration.react.js
@@ -11,6 +11,11 @@ const ConfigurationPage = React.createClass({
 
     this.setState({ darkTheme });
   },
+  toggleResize() {
+    const doResize = Utils.toggleResize();
+
+    this.setState({ doResize });
+  },
   changeLayout(event) {
     const layout = event.target.value;
 
@@ -36,6 +41,7 @@ const ConfigurationPage = React.createClass({
       showConsole: false,
       darkTheme : Utils.isDarkThemeActive(),
       layout: Utils.getActiveLayout(),
+      doResize: Utils.shouldResize(),
     };
   },
   render() {
@@ -66,6 +72,19 @@ const ConfigurationPage = React.createClass({
                   <option value="sticker">Sticker</option>
                 </select>
               </div>
+            </div>
+          </div>
+          <div className="form-group row">
+            <label className="col-sm-4">Resize when going fullscreen</label>
+            <div className="col-sm-8">
+              <Switch
+                isChecked={this.state.doResize}
+                onChange={this.toggleResize}
+                size="lg"
+                textOn="I"
+                textOff="O"
+                shape="square"
+                />
             </div>
           </div>
         </form>

--- a/src/client/scripts/pages/current-playlist.react.js
+++ b/src/client/scripts/pages/current-playlist.react.js
@@ -86,12 +86,17 @@ const Player = React.createClass({
     currentWindow.setVisibleOnAllWorkspaces(isFullScreen);
   },
   componentDidMount() {
+    const currentWindow = remote.getCurrentWindow();
+
     window.addEventListener('player.playNextVideo', this.playNextVideo);
     window.addEventListener('player.replayCurrentVideo', this.replayCurrentVideo);
     window.addEventListener('player.stopReplayCurrentVideo', this.stopReplayCurrentVideo);
 
-    if (Utils.getMode()) // Float-on-top mode
+    currentWindow.setFullScreenable(true);
+    if (Utils.getMode()) { // Float-on-top mode
       document.addEventListener('webkitfullscreenchange', this.onWebkitFullScreenChange);
+      currentWindow.setFullScreenable(false);
+    }
 
     this.setState({
       playlist: this.state.playlist,

--- a/src/client/scripts/pages/current-playlist.react.js
+++ b/src/client/scripts/pages/current-playlist.react.js
@@ -74,6 +74,8 @@ const Player = React.createClass({
       const currentWindow = remote.getCurrentWindow();
       const isFullScreen = Boolean(document.querySelector('#player:-webkit-full-screen'));
 
+      Utils.Socket.emit('player/fullscreen', isFullScreen);
+
       if (isFullScreen) {
         document.body.classList.add('fullscreen');
         currentWindow.setMinimumSize(160, 90);

--- a/src/client/scripts/pages/current-playlist.react.js
+++ b/src/client/scripts/pages/current-playlist.react.js
@@ -76,7 +76,8 @@ const Player = React.createClass({
       const currentWindow = remote.getCurrentWindow();
       const isFullScreen = Boolean(document.querySelector('#player:-webkit-full-screen'));
 
-      Utils.Socket.emit('player/fullscreen', isFullScreen);
+      if (Utils.shouldResize())
+        Utils.Socket.emit('player/fullscreen', isFullScreen);
 
       if (isFullScreen) {
         document.body.classList.add('fullscreen');
@@ -84,24 +85,6 @@ const Player = React.createClass({
       } else {
         document.body.classList.remove('fullscreen');
         currentWindow.setMinimumSize(880, 370);
-
-        // Resize window if too small
-        const currentSize = currentWindow.getSize();
-        let needResize = false;
-        let newWidth = currentSize[0];
-        let newHeight = currentSize[1];
-        if (newWidth < 880) {
-          needResize = true;
-          newWidth = 880;
-        }
-        if (newHeight < 370) {
-          needResize = true;
-          newHeight = 370;
-        }
-
-        if (needResize) {
-          currentWindow.setSize(newWidth, newHeight, true);
-        }
       }
 
       currentWindow.setAlwaysOnTop(isFullScreen);

--- a/src/client/scripts/pages/current-playlist.react.js
+++ b/src/client/scripts/pages/current-playlist.react.js
@@ -71,7 +71,7 @@ const Player = React.createClass({
     const currentWindow = remote.getCurrentWindow();
     const isFullScreen = Boolean(document.querySelector('#player:-webkit-full-screen'));
 
-    Utils.Socket.emit('player/fullscreen', isFullScreen);
+    Utils.Socket.emit('player/floatontop', isFullScreen);
 
     if (isFullScreen) {
       document.body.classList.add('fullscreen');

--- a/src/client/scripts/pages/current-playlist.react.js
+++ b/src/client/scripts/pages/current-playlist.react.js
@@ -67,30 +67,31 @@ const Player = React.createClass({
       playlist: nextProps.playlist,
     }, updatePlaylist);
   },
+  onWebkitFullScreenChange() {
+    const currentWindow = remote.getCurrentWindow();
+    const isFullScreen = Boolean(document.querySelector('#player:-webkit-full-screen'));
+
+    Utils.Socket.emit('player/fullscreen', isFullScreen);
+
+    if (isFullScreen) {
+      document.body.classList.add('fullscreen');
+      currentWindow.setMinimumSize(160, 90);
+    } else {
+      document.body.classList.remove('fullscreen');
+      currentWindow.setMinimumSize(880, 370);
+    }
+
+    currentWindow.setAlwaysOnTop(isFullScreen);
+    currentWindow.setHasShadow(!isFullScreen);
+    currentWindow.setVisibleOnAllWorkspaces(isFullScreen);
+  },
   componentDidMount() {
     window.addEventListener('player.playNextVideo', this.playNextVideo);
     window.addEventListener('player.replayCurrentVideo', this.replayCurrentVideo);
     window.addEventListener('player.stopReplayCurrentVideo', this.stopReplayCurrentVideo);
 
-    document.addEventListener('webkitfullscreenchange', () => {
-      const currentWindow = remote.getCurrentWindow();
-      const isFullScreen = Boolean(document.querySelector('#player:-webkit-full-screen'));
-
-      if (Utils.getMode())
-        Utils.Socket.emit('player/fullscreen', isFullScreen);
-
-      if (isFullScreen) {
-        document.body.classList.add('fullscreen');
-        currentWindow.setMinimumSize(160, 90);
-      } else {
-        document.body.classList.remove('fullscreen');
-        currentWindow.setMinimumSize(880, 370);
-      }
-
-      currentWindow.setAlwaysOnTop(isFullScreen);
-      currentWindow.setHasShadow(!isFullScreen);
-      currentWindow.setVisibleOnAllWorkspaces(isFullScreen);
-    }, false);
+    if (Utils.getMode()) // Float-on-top mode
+      document.addEventListener('webkitfullscreenchange', this.onWebkitFullScreenChange);
 
     this.setState({
       playlist: this.state.playlist,
@@ -108,6 +109,8 @@ const Player = React.createClass({
     });
   },
   componentWillUnmount() {
+    document.removeEventListener('webkitfullscreenchange', this.onWebkitFullScreenChange);
+
     window.removeEventListener('player.playNextVideo', this.playNextVideo);
     window.removeEventListener('player.replayCurrentVideo', this.replayCurrentVideo);
     window.removeEventListener('player.stopReplayCurrentVideo', this.stopReplayCurrentVideo);

--- a/src/client/scripts/pages/current-playlist.react.js
+++ b/src/client/scripts/pages/current-playlist.react.js
@@ -2,6 +2,8 @@ const { remote } = require('electron');
 const React = require('react');
 const _ = require('lodash');
 
+const Utils = require('../utils');
+
 let isPlaylistPlaying = false;
 
 const Player = React.createClass({

--- a/src/client/scripts/pages/current-playlist.react.js
+++ b/src/client/scripts/pages/current-playlist.react.js
@@ -76,7 +76,7 @@ const Player = React.createClass({
       const currentWindow = remote.getCurrentWindow();
       const isFullScreen = Boolean(document.querySelector('#player:-webkit-full-screen'));
 
-      if (Utils.shouldResize())
+      if (Utils.getMode())
         Utils.Socket.emit('player/fullscreen', isFullScreen);
 
       if (isFullScreen) {

--- a/src/client/scripts/utils.js
+++ b/src/client/scripts/utils.js
@@ -5,6 +5,15 @@ function isDarkThemeActive() {
   return document.body.classList.contains('dark');
 }
 
+function shouldResize() {
+  return castStringToBoolean(localStorage.getItem('doResize'));
+}
+
+function toggleResize() {
+  localStorage.setItem('doResize', castBooleanToString(!shouldResize()));
+  return shouldResize();
+}
+
 function getActiveLayout() {
   if (document.body.classList.contains('layout-overlay'))
     return 'overlay';
@@ -12,6 +21,10 @@ function getActiveLayout() {
     return 'sticker';
 
   return 'youtube';
+}
+
+function castStringToBoolean(string) {
+  return string === '1';
 }
 
 function castBooleanToString(boolean) {
@@ -23,4 +36,6 @@ module.exports = {
   isDarkThemeActive,
   getActiveLayout,
   castBooleanToString,
+  shouldResize,
+  toggleResize,
 };

--- a/src/client/scripts/utils.js
+++ b/src/client/scripts/utils.js
@@ -5,13 +5,13 @@ function isDarkThemeActive() {
   return document.body.classList.contains('dark');
 }
 
-function shouldResize() {
-  return castStringToBoolean(localStorage.getItem('doResize'));
+function getMode() {
+  return castStringToBoolean(localStorage.getItem('mode'));
 }
 
-function toggleResize() {
-  localStorage.setItem('doResize', castBooleanToString(!shouldResize()));
-  return shouldResize();
+function toggleMode() {
+  localStorage.setItem('mode', castBooleanToString(!getMode()));
+  return getMode();
 }
 
 function getActiveLayout() {
@@ -36,6 +36,6 @@ module.exports = {
   isDarkThemeActive,
   getActiveLayout,
   castBooleanToString,
-  shouldResize,
-  toggleResize,
+  getMode,
+  toggleMode,
 };

--- a/src/client/scripts/utils.js
+++ b/src/client/scripts/utils.js
@@ -11,6 +11,7 @@ function getMode() {
 
 function toggleMode() {
   localStorage.setItem('mode', castBooleanToString(!getMode()));
+  Socket.emit('config/mode', !getMode());
   return getMode();
 }
 

--- a/src/client/scripts/utils.js
+++ b/src/client/scripts/utils.js
@@ -11,7 +11,6 @@ function getMode() {
 
 function toggleMode() {
   localStorage.setItem('mode', castBooleanToString(!getMode()));
-  Socket.emit('config/mode', !getMode());
   return getMode();
 }
 

--- a/src/client/scripts/utils.js
+++ b/src/client/scripts/utils.js
@@ -1,16 +1,30 @@
+const Configstore = require('configstore');
+
 // eslint-disable-next-line no-undef
 const Socket = io('http://localhost:@@PORT');
+
+const configStore = new Configstore('YouWatch');
+let sortedDisplaysIds;
+
+Socket.on('number-of-display/update', onNumberOfDisplayChange);
 
 function isDarkThemeActive() {
   return document.body.classList.contains('dark');
 }
 
+function onNumberOfDisplayChange(_sortedDisplaysIds) {
+  sortedDisplaysIds = _sortedDisplaysIds;
+
+  if (!configStore.get('window.' + sortedDisplaysIds + '.preferedMode'))
+    configStore.set('window.' + sortedDisplaysIds + '.preferedMode', false);
+}
+
 function getMode() {
-  return castStringToBoolean(localStorage.getItem('mode'));
+  return configStore.get('window.' + sortedDisplaysIds + '.preferedMode');
 }
 
 function toggleMode() {
-  localStorage.setItem('mode', castBooleanToString(!getMode()));
+  configStore.set('window.' + sortedDisplaysIds + '.preferedMode', !getMode());
   return getMode();
 }
 
@@ -21,10 +35,6 @@ function getActiveLayout() {
     return 'sticker';
 
   return 'youtube';
-}
-
-function castStringToBoolean(string) {
-  return string === '1';
 }
 
 function castBooleanToString(boolean) {

--- a/src/config.js
+++ b/src/config.js
@@ -13,16 +13,4 @@ module.exports = {
   // and authorized redirect URIs on the Google Console
   PORT: 9000,
 
-  // The main window config
-  MAIN_WINDOW: {
-    WIDTH: 1200,
-    HEIGHT: 700,
-  },
-
-  // The auth window config
-  AUTH_WINDOW: {
-    WIDTH: 500,
-    HEIGHT: 600,
-  },
-
 };

--- a/src/windows.js
+++ b/src/windows.js
@@ -2,6 +2,7 @@ const electron = require('electron');
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const url = require('url');
+const _ = require('lodash');
 const Configstore = require('configstore');
 
 const configStore = new Configstore('YouWatch');
@@ -25,6 +26,7 @@ app.on('ready', () => {
   let isChangingMode = false;
   let primaryDisplay;
   let sortedDisplaysIds;
+  let onNumberOfDisplaysChangeHandler;
 
   function openMainWindow() {
     if (!windows[MAIN_WINDOW])
@@ -86,6 +88,7 @@ app.on('ready', () => {
 
   module.exports.openMainWindow = openMainWindow;
   module.exports.togglePlayerState = togglePlayerState;
+  module.exports.setOnNumberOfDisplayChangeHandler = setOnNumberOfDisplayChangeHandler;
 
   function onResize(windowName) {
     if (isChangingMode || primaryDisplay.id !== screen.getPrimaryDisplay().id)
@@ -132,6 +135,9 @@ app.on('ready', () => {
       const bounds = configStore.get(getConfigStoreWindow(isPlayerMaximized ? 'floatOnTop' : 'classic'));
       windows[windowName].setBounds(bounds, true);
     }
+
+    if (_.isFunction(onNumberOfDisplaysChangeHandler))
+      onNumberOfDisplaysChangeHandler(sortedDisplaysIds);
   }
 
   function getConfigStoreWindowKey() {
@@ -140,5 +146,10 @@ app.on('ready', () => {
 
   function getConfigStoreWindow(param) {
     return getConfigStoreWindowKey() + '.' + param;
+  }
+
+  function setOnNumberOfDisplayChangeHandler(handler) {
+    onNumberOfDisplaysChangeHandler = handler;
+    onNumberOfDisplaysChangeHandler(sortedDisplaysIds);
   }
 });

--- a/src/windows.js
+++ b/src/windows.js
@@ -1,17 +1,19 @@
 const { app, BrowserWindow } = require('electron');
-const Configstore = require('configstore');
 const path = require('path');
+const url = require('url');
+const Configstore = require('configstore');
 
 const configStore = new Configstore('YouWatch');
 
-const isMac = process.platform === 'darwin';
-const MAIN_WINDOW = 'main';
-const ICON = path.join(__dirname, '..', 'static', 'icon.png');
-const url = require('url').format({
+const pageUrl = url.format({
   protocol: 'file',
   slashes: true,
   pathname: path.join(__dirname, 'client', 'index.html')
 });
+
+const isMac = process.platform === 'darwin';
+const MAIN_WINDOW = 'main';
+const ICON = path.join(__dirname, '..', 'static', 'icon.png');
 
 const windows = {};
 
@@ -42,13 +44,21 @@ function createMainWindow() {
   if (require('electron-is-dev'))
     _window.openDevTools();
 
-  _window.loadURL(url);
+  _window.loadURL(pageUrl);
+  _window.on('resize', onResize.bind(null, MAIN_WINDOW));
   _window.on('closed', onClosed.bind(null, MAIN_WINDOW));
 
   return _window;
 }
 
 module.exports.openMainWindow = openMainWindow;
+
+function onResize(windowName) {
+  const size = windows[windowName].getSize();
+
+  configStore.set('width', size[0]);
+  configStore.set('height', size[1]);
+}
 
 function onClosed(windowName) {
   // dereference the window

--- a/src/windows.js
+++ b/src/windows.js
@@ -55,14 +55,17 @@ app.on('ready', () => {
     if (isMac)
       app.dock.setIcon(ICON);
 
-    if (require('electron-is-dev'))
-      _window.openDevTools();
-
     _window.loadURL(pageUrl);
+
+    _window.on('ready-to-show', () => {
+      if (require('electron-is-dev'))
+        _window.openDevTools();
+
+      _window.show();
+    });
 
     _window.on('resize', () => onResize(MAIN_WINDOW));
     _window.on('move', () => onResize(MAIN_WINDOW));
-    _window.on('ready-to-show', () => _window.show());
     _window.on('closed', () => onClosed(MAIN_WINDOW));
 
     screen.on('display-added', () => onNumberOfDisplaysChange(MAIN_WINDOW));

--- a/src/windows.js
+++ b/src/windows.js
@@ -10,8 +10,6 @@ const url = require('url').format({
   pathname: path.join(__dirname, 'client', 'index.html')
 });
 
-const CONFIG = require('./config');
-
 const windows = {};
 
 function openMainWindow() {
@@ -22,8 +20,8 @@ function openMainWindow() {
 function createMainWindow() {
   const _window = new BrowserWindow({
     title: app.getName(),
-    width: CONFIG.MAIN_WINDOW.WIDTH,
-    height: CONFIG.MAIN_WINDOW.HEIGHT,
+    width: 1600,
+    height: 900,
     icon: ICON,
     autoHideMenuBar: true,
     minWidth: 880,

--- a/src/windows.js
+++ b/src/windows.js
@@ -60,7 +60,6 @@ app.on('ready', () => {
       minHeight: 370,
       frame: isMac,
       titleBarStyle: 'hidden-inset',
-      fullscreenable: false, // so that the youtube videos go fullscreen inside the window, not in the screen
       alwaysOnTop: false,
       hasShadow: true,
       enableLargerThanScreen: true,
@@ -81,10 +80,6 @@ app.on('ready', () => {
     return _window;
   }
 
-  function switchMode(mode) {
-    windows[MAIN_WINDOW].setFullScreenable(mode);
-  }
-
   function toggleFullscreen(_isFullscreen) {
     const bounds = configStore.get('window.' + (_isFullscreen ? 'fullscreen' : 'classic'));
 
@@ -96,7 +91,6 @@ app.on('ready', () => {
   }
 
   module.exports.openMainWindow = openMainWindow;
-  module.exports.switchMode = switchMode;
   module.exports.toggleFullscreen = toggleFullscreen;
 
   function onResize(windowName) {

--- a/src/windows.js
+++ b/src/windows.js
@@ -98,7 +98,7 @@ app.on('ready', () => {
       return;
 
     const bounds = windows[windowName].getBounds();
-    const key = 'window.' + (_isPlayerMaximized ? 'floatOnTop' : 'classic');
+    const key = 'window.' + (isPlayerMaximized ? 'floatOnTop' : 'classic');
     configStore.set(key, bounds);
   }
 

--- a/src/windows.js
+++ b/src/windows.js
@@ -13,13 +13,13 @@ const configStore = new Configstore('YouWatch', {
       width: 640,
       height: 380,
     },
-  }
+  },
 });
 
 const pageUrl = url.format({
   protocol: 'file',
   slashes: true,
-  pathname: path.join(__dirname, 'client', 'index.html')
+  pathname: path.join(__dirname, 'client', 'index.html'),
 });
 
 const isMac = process.platform === 'darwin';

--- a/src/windows.js
+++ b/src/windows.js
@@ -28,8 +28,8 @@ app.on('ready', () => {
   };
 
   const configStore = new Configstore('YouWatch');
-  if (!configStore.get('window.' + sortedDisplaysIds))
-    configStore.set('window.' + sortedDisplaysIds, defaultConfig);
+  if (!configStore.get(getConfigStoreWindowKey()))
+    configStore.set(getConfigStoreWindowKey(), defaultConfig);
 
   const pageUrl = url.format({
     protocol: 'file',
@@ -53,10 +53,10 @@ app.on('ready', () => {
   function createMainWindow() {
     const _window = new BrowserWindow({
       title: app.getName(),
-      x: configStore.get('window.' + sortedDisplaysIds + '.classic.x'),
-      y: configStore.get('window.' + sortedDisplaysIds + '.classic.y'),
-      width: configStore.get('window.' + sortedDisplaysIds + '.classic.width'),
-      height: configStore.get('window.' + sortedDisplaysIds + '.classic.height'),
+      x: configStore.get(getConfigStoreWindow('classic.x')),
+      y: configStore.get(getConfigStoreWindow('classic.y')),
+      width: configStore.get(getConfigStoreWindow('classic.width')),
+      height: configStore.get(getConfigStoreWindow('classic.height')),
       icon: ICON,
       autoHideMenuBar: true,
       minWidth: 880,
@@ -84,7 +84,7 @@ app.on('ready', () => {
   }
 
   function togglePlayerState(_isPlayerMaximized) {
-    const bounds = configStore.get('window.' + sortedDisplaysIds + '.' + (_isPlayerMaximized ? 'floatOnTop' : 'classic'));
+    const bounds = configStore.get(getConfigStoreWindow(_isPlayerMaximized ? 'floatOnTop' : 'classic'));
 
     isChangingMode = true;
     windows[MAIN_WINDOW].setBounds(bounds, true);
@@ -101,12 +101,20 @@ app.on('ready', () => {
       return;
 
     const bounds = windows[windowName].getBounds();
-    const key = 'window.' + sortedDisplaysIds + '.' + (isPlayerMaximized ? 'floatOnTop' : 'classic');
+    const key = getConfigStoreWindow(isPlayerMaximized ? 'floatOnTop' : 'classic');
     configStore.set(key, bounds);
   }
 
   function onClosed(windowName) {
     // dereference the window
     windows[windowName] = null;
+  }
+
+  function getConfigStoreWindowKey() {
+    return 'window.' + sortedDisplaysIds;
+  }
+
+  function getConfigStoreWindow(param) {
+    return getConfigStoreWindowKey() + '.' + param;
   }
 });

--- a/src/windows.js
+++ b/src/windows.js
@@ -81,6 +81,10 @@ app.on('ready', () => {
     return _window;
   }
 
+  function switchMode(mode) {
+    windows[MAIN_WINDOW].setFullScreenable(mode);
+  }
+
   function toggleFullscreen(_isFullscreen) {
     const bounds = configStore.get('window.' + (_isFullscreen ? 'fullscreen' : 'classic'));
 
@@ -92,6 +96,7 @@ app.on('ready', () => {
   }
 
   module.exports.openMainWindow = openMainWindow;
+  module.exports.switchMode = switchMode;
   module.exports.toggleFullscreen = toggleFullscreen;
 
   function onResize(windowName) {

--- a/src/windows.js
+++ b/src/windows.js
@@ -19,7 +19,7 @@ app.on('ready', () => {
         width: appWidth,
         height: appHeight,
       },
-      fullscreen: {
+      floatOnTop: {
         x: screenWidth - 640,
         y: screenHeight - 380,
         width: 640,
@@ -39,7 +39,7 @@ app.on('ready', () => {
   const ICON = path.join(__dirname, '..', 'static', 'icon.png');
 
   const windows = {};
-  let isFullscreen = false;
+  let isPlayerMaximized = false;
   let isChangingMode = false;
 
   function openMainWindow() {
@@ -80,25 +80,25 @@ app.on('ready', () => {
     return _window;
   }
 
-  function toggleFullscreen(_isFullscreen) {
-    const bounds = configStore.get('window.' + (_isFullscreen ? 'fullscreen' : 'classic'));
+  function togglePlayerState(_isPlayerMaximized) {
+    const bounds = configStore.get('window.' + (_isPlayerMaximized ? 'floatOnTop' : 'classic'));
 
     isChangingMode = true;
     windows[MAIN_WINDOW].setBounds(bounds, true);
     isChangingMode = false;
 
-    isFullscreen = _isFullscreen;
+    isPlayerMaximized = _isPlayerMaximized;
   }
 
   module.exports.openMainWindow = openMainWindow;
-  module.exports.toggleFullscreen = toggleFullscreen;
+  module.exports.togglePlayerState = togglePlayerState;
 
   function onResize(windowName) {
     if (isChangingMode)
       return;
 
     const bounds = windows[windowName].getBounds();
-    const key = 'window.' + (isFullscreen ? 'fullscreen' : 'classic');
+    const key = 'window.' + (_isPlayerMaximized ? 'floatOnTop' : 'classic');
     configStore.set(key, bounds);
   }
 

--- a/src/windows.js
+++ b/src/windows.js
@@ -60,13 +60,13 @@ app.on('ready', () => {
 
     _window.loadURL(pageUrl);
 
-    _window.on('resize', onResize.bind(null, MAIN_WINDOW));
-    _window.on('move', onResize.bind(null, MAIN_WINDOW));
+    _window.on('resize', () => onResize(MAIN_WINDOW));
+    _window.on('move', () => onResize(MAIN_WINDOW));
     _window.on('ready-to-show', () => _window.show());
-    _window.on('closed', onClosed.bind(null, MAIN_WINDOW));
+    _window.on('closed', () => onClosed(MAIN_WINDOW));
 
-    screen.on('display-added', onNumberOfDisplaysChange);
-    screen.on('display-removed', onNumberOfDisplaysChange);
+    screen.on('display-added', () => onNumberOfDisplaysChange(MAIN_WINDOW));
+    screen.on('display-removed', () => onNumberOfDisplaysChange(MAIN_WINDOW));
 
     return _window;
   }
@@ -98,7 +98,7 @@ app.on('ready', () => {
     windows[windowName] = null;
   }
 
-  function onNumberOfDisplaysChange() {
+  function onNumberOfDisplaysChange(windowName) {
     sortedDisplaysIds = screen.getAllDisplays().map((display) => display.id).sort().join('-');
     primaryDisplay = screen.getPrimaryDisplay();
 
@@ -125,9 +125,9 @@ app.on('ready', () => {
       configStore.set(getConfigStoreWindowKey(), defaultConfig);
     }
 
-    if (windows[MAIN_WINDOW]) {
+    if (windows[windowName]) {
       const bounds = configStore.get(getConfigStoreWindow(isPlayerMaximized ? 'floatOnTop' : 'classic'));
-      windows[MAIN_WINDOW].setBounds(bounds, true);
+      windows[windowName].setBounds(bounds, true);
     }
   }
 

--- a/src/windows.js
+++ b/src/windows.js
@@ -26,14 +26,14 @@ app.on('ready', () => {
   let primaryDisplay;
   let sortedDisplaysIds;
 
-  onNumberOfDisplaysChange();
-
   function openMainWindow() {
     if (!windows[MAIN_WINDOW])
       windows[MAIN_WINDOW] = createMainWindow();
   }
 
   function createMainWindow() {
+    onNumberOfDisplaysChange();
+
     const _window = new BrowserWindow({
       title: app.getName(),
       x: configStore.get(getConfigStoreWindow('classic.x')),
@@ -100,7 +100,7 @@ app.on('ready', () => {
     sortedDisplaysIds = screen.getAllDisplays().map((display) => display.id).sort().join('-');
     primaryDisplay = screen.getPrimaryDisplay();
 
-    if (!windows[MAIN_WINDOW] || !configStore.get(getConfigStoreWindowKey())) {
+    if (!configStore.get(getConfigStoreWindowKey())) {
       const { width: screenWidth, height: screenHeight } = primaryDisplay.size;
       const appWidth = 0.75 * screenWidth;
       const appHeight = 0.75 * screenHeight;

--- a/src/windows.js
+++ b/src/windows.js
@@ -21,9 +21,9 @@ app.on('ready', () => {
       },
       floatOnTop: {
         x: screenWidth - 640,
-        y: screenHeight - 380,
+        y: screenHeight - 360,
         width: 640,
-        height: 380,
+        height: 360,
       },
     },
   });

--- a/src/windows.js
+++ b/src/windows.js
@@ -6,8 +6,8 @@ const Configstore = require('configstore');
 
 app.on('ready', () => {
   const primaryDisplay = electron.screen.getPrimaryDisplay();
-  const screenWidth = primaryDisplay.bounds.width;
-  const screenHeight = primaryDisplay.bounds.height;
+
+  const { width: screenWidth, height: screenHeight } = primaryDisplay.size;
   const appWidth = 0.75 * screenWidth;
   const appHeight = 0.75 * screenHeight;
 

--- a/src/windows.js
+++ b/src/windows.js
@@ -1,5 +1,8 @@
 const { app, BrowserWindow } = require('electron');
+const Configstore = require('configstore');
 const path = require('path');
+
+const configStore = new Configstore('YouWatch');
 
 const isMac = process.platform === 'darwin';
 const MAIN_WINDOW = 'main';
@@ -20,8 +23,8 @@ function openMainWindow() {
 function createMainWindow() {
   const _window = new BrowserWindow({
     title: app.getName(),
-    width: 1600,
-    height: 900,
+    width: configStore.get('width') || 1600,
+    height: configStore.get('height') || 900,
     icon: ICON,
     autoHideMenuBar: true,
     minWidth: 880,

--- a/src/windows.js
+++ b/src/windows.js
@@ -1,95 +1,110 @@
+const electron = require('electron');
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const url = require('url');
 const Configstore = require('configstore');
 
-const configStore = new Configstore('YouWatch', {
-  window: {
-    classic: {
-      width: 1200,
-      height: 800,
+app.on('ready', () => {
+  const primaryDisplay = electron.screen.getPrimaryDisplay();
+  const screenWidth = primaryDisplay.bounds.width;
+  const screenHeight = primaryDisplay.bounds.height;
+  const appWidth = 0.75 * screenWidth;
+  const appHeight = 0.75 * screenHeight;
+
+  const configStore = new Configstore('YouWatch', {
+    window: {
+      classic: {
+        x: (screenWidth / 2.0) - (appWidth / 2.0),
+        y: (screenHeight / 2.0) - (appHeight / 2.0),
+        width: appWidth,
+        height: appHeight,
+      },
+      fullscreen: {
+        x: screenWidth - 640,
+        y: screenHeight - 380,
+        width: 640,
+        height: 380,
+      },
     },
-    fullscreen: {
-      width: 640,
-      height: 380,
-    },
-  },
-});
-
-const pageUrl = url.format({
-  protocol: 'file',
-  slashes: true,
-  pathname: path.join(__dirname, 'client', 'index.html'),
-});
-
-const isMac = process.platform === 'darwin';
-const MAIN_WINDOW = 'main';
-const ICON = path.join(__dirname, '..', 'static', 'icon.png');
-
-const windows = {};
-let isFullscreen = false;
-let isChangingMode = false;
-
-function openMainWindow() {
-  if (!windows[MAIN_WINDOW])
-    windows[MAIN_WINDOW] = createMainWindow();
-}
-
-function createMainWindow() {
-  const _window = new BrowserWindow({
-    title: app.getName(),
-    width: configStore.get('window.classic.width'),
-    height: configStore.get('window.classic.height'),
-    icon: ICON,
-    autoHideMenuBar: true,
-    minWidth: 880,
-    minHeight: 370,
-    frame: isMac,
-    titleBarStyle: 'hidden-inset',
-    fullscreenable: false, // so that the youtube videos go fullscreen inside the window, not in the screen
-    alwaysOnTop: false,
-    hasShadow: true,
   });
 
-  if (isMac)
-    app.dock.setIcon(ICON);
-
-  if (require('electron-is-dev'))
-    _window.openDevTools();
-
-  _window.loadURL(pageUrl);
-  _window.on('resize', onResize.bind(null, MAIN_WINDOW));
-  _window.on('closed', onClosed.bind(null, MAIN_WINDOW));
-
-  return _window;
-}
-
-function toggleFullscreen(_isFullscreen) {
-  const size = configStore.get('window.' + (_isFullscreen ? 'fullscreen' : 'classic'));
-
-  isChangingMode = true;
-  windows[MAIN_WINDOW].setSize(size.width, size.height);
-  isChangingMode = false;
-
-  isFullscreen = _isFullscreen;
-}
-
-module.exports.openMainWindow = openMainWindow;
-module.exports.toggleFullscreen = toggleFullscreen;
-
-function onResize(windowName) {
-  if (isChangingMode)
-    return;
-
-  const size = windows[windowName].getSize();
-  const key = 'window.' + (isFullscreen ? 'fullscreen' : 'classic');
-  configStore.set(key, {
-    width: size[0],
-    height: size[1],
+  const pageUrl = url.format({
+    protocol: 'file',
+    slashes: true,
+    pathname: path.join(__dirname, 'client', 'index.html'),
   });
-}
 
-function onClosed(windowName) {
-  // dereference the window
-  windows[windowName] = null;
-}
+  const isMac = process.platform === 'darwin';
+  const MAIN_WINDOW = 'main';
+  const ICON = path.join(__dirname, '..', 'static', 'icon.png');
+
+  const windows = {};
+  let isFullscreen = false;
+  let isChangingMode = false;
+
+  function openMainWindow() {
+    if (!windows[MAIN_WINDOW])
+      windows[MAIN_WINDOW] = createMainWindow();
+  }
+
+  function createMainWindow() {
+    const _window = new BrowserWindow({
+      title: app.getName(),
+      x: configStore.get('window.classic.x'),
+      y: configStore.get('window.classic.y'),
+      width: configStore.get('window.classic.width'),
+      height: configStore.get('window.classic.height'),
+      icon: ICON,
+      autoHideMenuBar: true,
+      minWidth: 880,
+      minHeight: 370,
+      frame: isMac,
+      titleBarStyle: 'hidden-inset',
+      fullscreenable: false, // so that the youtube videos go fullscreen inside the window, not in the screen
+      alwaysOnTop: false,
+      hasShadow: true,
+      enableLargerThanScreen: true,
+    });
+
+    if (isMac)
+      app.dock.setIcon(ICON);
+
+    if (require('electron-is-dev'))
+      _window.openDevTools();
+
+    _window.loadURL(pageUrl);
+    _window.on('resize', onResize.bind(null, MAIN_WINDOW));
+    _window.on('move', onResize.bind(null, MAIN_WINDOW));
+
+    _window.on('closed', onClosed.bind(null, MAIN_WINDOW));
+
+    return _window;
+  }
+
+  function toggleFullscreen(_isFullscreen) {
+    const bounds = configStore.get('window.' + (_isFullscreen ? 'fullscreen' : 'classic'));
+
+    isChangingMode = true;
+    windows[MAIN_WINDOW].setBounds(bounds, true);
+    isChangingMode = false;
+
+    isFullscreen = _isFullscreen;
+  }
+
+  module.exports.openMainWindow = openMainWindow;
+  module.exports.toggleFullscreen = toggleFullscreen;
+
+  function onResize(windowName) {
+    if (isChangingMode)
+      return;
+
+    const bounds = windows[windowName].getBounds();
+    const key = 'window.' + (isFullscreen ? 'fullscreen' : 'classic');
+    configStore.set(key, bounds);
+  }
+
+  function onClosed(windowName) {
+    // dereference the window
+    windows[windowName] = null;
+  }
+});

--- a/src/windows.js
+++ b/src/windows.js
@@ -49,6 +49,7 @@ app.on('ready', () => {
       alwaysOnTop: false,
       hasShadow: true,
       enableLargerThanScreen: true,
+      show: false,
     });
 
     if (isMac)
@@ -58,9 +59,10 @@ app.on('ready', () => {
       _window.openDevTools();
 
     _window.loadURL(pageUrl);
+
     _window.on('resize', onResize.bind(null, MAIN_WINDOW));
     _window.on('move', onResize.bind(null, MAIN_WINDOW));
-
+    _window.on('ready-to-show', () => _window.show());
     _window.on('closed', onClosed.bind(null, MAIN_WINDOW));
 
     screen.on('display-added', onNumberOfDisplaysChange);


### PR DESCRIPTION
Add a switch in the config page to switch between fullscreen and float-on-top mode. See #9 

Window sizes and positions are saved in "classic" mode and "float-on-top" mode, on different screens. Connecting or disconnecting a screen when the app is launched could be buggy.